### PR TITLE
Allow to pass arguments to scripts

### DIFF
--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -1,39 +1,44 @@
 import nengo_gui.swi
 from nengo_gui.server import NengoGui
 
-import optparse
+import argparse
+
 
 def main():
-    parser = optparse.OptionParser()
-    parser.add_option('-p', '--password', dest='password', metavar='PASS',
-                      default=None, help='password for remote access')
-    parser.add_option('-r', '--refresh', dest='refresh', metavar='TIME',
-                      default=0, help='interval to check server for changes',
-                      type='int')
-    parser.add_option('-s', '--simulator', dest='simulator', metavar='SIM',
-                      default="nengo", type='str', help='simulator platform')
-    parser.add_option('-P', '--port', dest='port', metavar='PORT',
-                      default=8080, type='int', help='port to run server on')
-    (options, args) = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-p', '--password', dest='password', metavar='PASS',
+        help='password for remote access')
+    parser.add_argument(
+        '-r', '--refresh', dest='refresh', metavar='TIME',
+        default=0, help='interval to check server for changes', type=int)
+    parser.add_argument(
+        '-s', '--simulator', dest='simulator', metavar='SIM',
+        default="nengo", type=str, help='simulator platform')
+    parser.add_argument(
+        '-P', '--port', dest='port', metavar='PORT',
+        default=8080, type=int, help='port to run server on')
+    parser.add_argument(
+        'filename', nargs='?', type=str, help='initial file to load')
+    args = parser.parse_args()
 
-    NengoGui.set_refresh_interval(options.refresh)
-    NengoGui.set_simulator_class(__import__(options.simulator).Simulator)
-    if options.simulator in ['nengo_spinnaker']:
+    NengoGui.set_refresh_interval(args.refresh)
+    NengoGui.set_simulator_class(__import__(args.simulator).Simulator)
+    if args.simulator in ['nengo_spinnaker']:
         # TODO: Simulators should have a supports_realtime() flag
         NengoGui.set_realtime_simulator_mode(True)
 
-
-    if len(args) > 0:
-        NengoGui.set_default_filename(args[0])
+    if args.filename is not None:
+        NengoGui.set_default_filename(args.filename)
 
     addr = 'localhost'
-    if options.password is not None:
-        nengo_gui.swi.addUser('', options.password)
+    if args.password is not None:
+        nengo_gui.swi.addUser('', args.password)
         addr = ''   # allow connections from anywhere
     else:
-        nengo_gui.swi.browser(options.port)
+        nengo_gui.swi.browser(args.port)
 
-    nengo_gui.swi.start(NengoGui, options.port, addr=addr)
+    nengo_gui.swi.start(NengoGui, args.port, addr=addr)
 
 if __name__ == '__main__':
     main()

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -20,6 +20,9 @@ def main():
         default=8080, type=int, help='port to run server on')
     parser.add_argument(
         'filename', nargs='?', type=str, help='initial file to load')
+    parser.add_argument(
+        'options', nargs=argparse.REMAINDER,
+        help='options to be passed on to the script')
     args = parser.parse_args()
 
     NengoGui.set_refresh_interval(args.refresh)
@@ -29,7 +32,7 @@ def main():
         NengoGui.set_realtime_simulator_mode(True)
 
     if args.filename is not None:
-        NengoGui.set_default_filename(args.filename)
+        NengoGui.set_default_filename(args.filename, args.options)
 
     addr = 'localhost'
     if args.password is not None:


### PR DESCRIPTION
This PR allows to specifiy arguments to the script on the command line (in addition to the filename).

It is based on the `argparse` branch.

This PR might not be the final implementation, but merely the basis for discussion. Probably the arguments should be reset if another file is loaded. Maybe there are better ways to actually pass the arguments into the code.